### PR TITLE
Fix Heroku remote regexp to handle https URLs

### DIFF
--- a/plugin/heroku.vim
+++ b/plugin/heroku.vim
@@ -215,7 +215,7 @@ function! s:Detect(git_dir) abort
       if !empty(remote)
         let alias = remote
       endif
-      let app = matchstr(line, '^\s*url\s*=.*heroku.com:\zs.*\ze\.git\s*$')
+      let app = matchstr(line, '^\s*url\s*=.*heroku.com/\zs.*\ze\.git\s*$')
       if !empty(app)
         let remotes[alias] = app
       endif


### PR DESCRIPTION
Having used the `heroku git:remote --app myapp-staging --remote staging`
command to add heroku remotes, I have the following in my
$project_root/.git/config:

```
[remote "staging"]
       url = https://git.heroku.com/myapp-staging.git
       fetch = +refs/heads/*:refs/remotes/staging/*
[remote "production"]
       url = https://git.heroku.com/myapp-production.git
       fetch = +refs/heads/*:refs/remotes/production/*
```

These urls are not matched by
https://github.com/tpope/vim-heroku/blob/13351fae74cc9e9e86d6421bab8499a1c9359cef/plugin/heroku.vim#L218,
which assumes a `:` instead of a `/` before the app name.

This leads to not having :Staging or :Production commands despite those
remotes being present.

Replace the `:` with a `/` in the Regexp to properly match these URLs.
